### PR TITLE
Define  NODE_CLASS_MAPPINGS

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -60,3 +60,5 @@ LIMIT 10;
         result = [dict(row) for row in rows]
     body = json.dumps(result)
     return web.Response(body=body,status=200)
+
+NODE_CLASS_MAPPINGS = {}


### PR DESCRIPTION
Defining NODE_CLASS_MAPPINGS = {} to allow module loading in the recent versions of ComfyUI.
Should resolve issues #1 and #2 